### PR TITLE
Add sign address field for PSBT combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ The app allows you to combine multiple PSBT hex strings into one transaction.
 
 1. Connect your wallet.
 2. In the **Combine PSBTs** section paste a JSON array of PSBT strings or several hex strings separated by new lines.
-3. Click **Combine** to merge, finalize and broadcast the transaction.
-4. The result or any error message will appear in the **Result** area.
+3. Enter the address that should sign the transaction.
+4. Click **Combine** to merge, finalize and broadcast the transaction.
+5. The result or any error message will appear in the **Result** area.

--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ export default function App() {
   const [psbtListInput, setPsbtListInput] = useState("");
   const [amount, setAmount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [signAddress, setSignAddress] = useState("");
 
   const getProvider = useCallback(() => {
     if (window.SubWalletBitcoin) {
@@ -167,13 +168,15 @@ export default function App() {
         psbt: base.toHex(),
         broadcast: true,
         network: "testnet",
+        address: signAddress,
+        signAtIndex: [],
       });
 
       setResultHash(result.txid || txHex);
     } catch (e) {
       setError(e.message || `${e}`);
     }
-  }, [provider, getProvider, psbtListInput]);
+  }, [provider, getProvider, psbtListInput, signAddress]);
 
   const onChangeAddressRecipient = useCallback((event) => {
     setRecipient(event.target.value);
@@ -189,6 +192,10 @@ export default function App() {
 
   const onChangePsbtList = useCallback((event) => {
     setPsbtListInput(event.target.value);
+  }, []);
+
+  const onChangeSignAddress = useCallback((event) => {
+    setSignAddress(event.target.value);
   }, []);
 
   const onChangeAmount = useCallback((event) => {
@@ -252,6 +259,12 @@ export default function App() {
       </div>
       <div className="row">
         <h2>Combine PSBTs</h2>
+
+        <input
+          placeholder="Address"
+          value={signAddress}
+          onChange={onChangeSignAddress}
+        />
 
         <textarea
           placeholder="PSBT list"


### PR DESCRIPTION
## Summary
- allow specifying an address when combining PSBTs
- send `signAtIndex: []` along with the address
- document the new step in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684fdbed8ed883218bf12a3c4ad663a4