### PR TITLE
Allow combining PSBTs without wallet signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ The app allows you to combine multiple PSBT hex strings into one transaction.
 
 1. Connect your wallet.
 2. In the **Combine PSBTs** section paste a JSON array of PSBT strings or several hex strings separated by new lines.
-3. Enter the address that should sign the transaction.
-4. Click **Combine** to merge, finalize and broadcast the transaction.
-5. The result or any error message will appear in the **Result** area.
+3. Click **Combine** to merge all PSBTs, finalize them and broadcast the raw
+   transaction through Blockstream's testnet API.
+4. The result or any error message will appear in the **Result** area.

--- a/src/App.js
+++ b/src/App.js
@@ -164,19 +164,19 @@ export default function App() {
       base.finalizeAllInputs();
       const txHex = base.extractTransaction().toHex();
 
-      const result = await provider.request("signPsbt", {
-        psbt: base.toHex(),
-        broadcast: true,
-        network: "testnet",
-        address: signAddress,
-        signAtIndex: [],
+      const resp = await fetch("https://blockstream.info/testnet/api/tx", {
+        method: "POST",
+        body: txHex,
+        headers: { "Content-Type": "text/plain" },
       });
 
-      setResultHash(result.txid || txHex);
+      const txid = await resp.text();
+
+      setResultHash(txid || txHex);
     } catch (e) {
       setError(e.message || `${e}`);
     }
-  }, [provider, getProvider, psbtListInput, signAddress]);
+  }, [provider, getProvider, psbtListInput]);
 
   const onChangeAddressRecipient = useCallback((event) => {
     setRecipient(event.target.value);


### PR DESCRIPTION
## Summary
- drop call to `signPsbt` in combine step
- finalize and broadcast the transaction directly
- update README usage instructions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6850031768888321a257d588b565ef9b